### PR TITLE
Add Hashicorp Vault argoCD app for infra cluster

### DIFF
--- a/clusters/nerc-ocp-infra/vault/application.yaml
+++ b/clusters/nerc-ocp-infra/vault/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: vault/overlays/nerc-ocp-infra
+  destination:
+    name: nerc-ocp-infra
+    namespace: vault
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/clusters/nerc-ocp-infra/vault/kustomization.yaml
+++ b/clusters/nerc-ocp-infra/vault/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml


### PR DESCRIPTION
Adding the argoCD application manifests for Hashicorp Vault deployment in infra cluster.