### PR TITLE
Nerc xdmod deploy

### DIFF
--- a/clusters/nerc-ocp-infra/kustomization.yaml
+++ b/clusters/nerc-ocp-infra/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - openshift-gitops
   - vault
   - acm
+  - xdmod

--- a/clusters/nerc-ocp-infra/xdmod/application.yaml
+++ b/clusters/nerc-ocp-infra/xdmod/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: xdmod
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/CCI-MOC/xdmod-cntr.git
+    targetRevision: HEAD
+    path: k8s/overlays/nerc-ocp-infra
+  destination:
+    name: nerc-ocp-infra
+    namespace: xdmod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/clusters/nerc-ocp-infra/xdmod/kustomization.yaml
+++ b/clusters/nerc-ocp-infra/xdmod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - application.yaml


### PR DESCRIPTION
Added the yaml to so that ArgoCD can deploy from the xdmod-cntr project.

This is meant to work with (https://github.com/CCI-MOC/xdmod-cntr/pull/64)