### PR TITLE
Add openshift-acct-mgt application

### DIFF
--- a/clusters/nerc-ocp-prod/acct-mgt/application.yaml
+++ b/clusters/nerc-ocp-prod/acct-mgt/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: acct-mgt
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: acct-mgt/overlays/nerc-ocp-prod
+  destination:
+    name: nerc-ocp-prod
+    namespace: acct-mgt
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/clusters/nerc-ocp-prod/acct-mgt/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/acct-mgt/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - application.yaml

--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../lib/cluster-scope
 - ../lib/logging
+- acct-mgt
 - fake-metrics-server
 
 nameSuffix: -prod


### PR DESCRIPTION
Adds `openshift-acct-mgt` to ArgoCD.

Related: https://github.com/OCP-on-NERC/nerc-ocp-config/pull/66 