### PR TITLE
Retry failed sync for xdmod application

### DIFF
--- a/clusters/nerc-ocp-infra/xdmod/application.yaml
+++ b/clusters/nerc-ocp-infra/xdmod/application.yaml
@@ -17,3 +17,9 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=false
+    retry:
+      limit: -1
+      backoff:
+        duration: 60s
+        factor: 2
+        maxDuration: 30min


### PR DESCRIPTION
It turns out that after a failed sync, ArgoCD will by default no longer
attempt to auto-sync the resource [1]. This commit enables sync retries
with exponential backoff as described in [2].

[1]: https://github.com/argoproj/argo-cd/issues/4101
[2]: https://github.com/argoproj/argo-cd/pull/3997
