### PR TITLE
Add ocp-prod cluster-scope application to argocd

### DIFF
--- a/clusters/nerc-ocp-prod/cluster-scope/application.yaml
+++ b/clusters/nerc-ocp-prod/cluster-scope/application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nerc-ocp-prod-cluster-scope
+spec:
+  destination:
+    name: nerc-ocp-prod
+    namespace: openshift-gitops
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    path: cluster-scope/overlays/nerc-ocp-prod
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+    - ApplyOutOfSyncOnly=true

--- a/clusters/nerc-ocp-prod/cluster-scope/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/cluster-scope/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-scope/


### PR DESCRIPTION
This will cause argocd to start managing the configuration of nerc-ocp-prod
