### PR TITLE
Centrally manage application syncPolicy

### DIFF
--- a/clusters/nerc-ocp-infra/acm/application.yaml
+++ b/clusters/nerc-ocp-infra/acm/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: nerc-ocp-infra-acm
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   destination:
     name: nerc-ocp-infra
@@ -11,8 +13,3 @@ spec:
     path: acm/overlays/nerc-ocp-infra
     repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
     targetRevision: HEAD
-  syncPolicy:
-    automated:
-      selfHeal: true
-    syncOptions:
-      - ApplyOutOfSyncOnly=true

--- a/clusters/nerc-ocp-infra/cluster-scope/application.yaml
+++ b/clusters/nerc-ocp-infra/cluster-scope/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: nerc-ocp-infra-cluster-scope
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   destination:
     name: nerc-ocp-infra
@@ -11,8 +13,3 @@ spec:
     path: cluster-scope/overlays/nerc-ocp-infra
     repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
     targetRevision: HEAD
-  syncPolicy:
-    automated:
-      selfHeal: true
-    syncOptions:
-    - ApplyOutOfSyncOnly=true

--- a/clusters/nerc-ocp-infra/dex/application.yaml
+++ b/clusters/nerc-ocp-infra/dex/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: dex
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   project: default
   source:
@@ -11,9 +13,3 @@ spec:
   destination:
     name: nerc-ocp-infra
     namespace: dex
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - Validate=false

--- a/clusters/nerc-ocp-infra/grafana/application.yaml
+++ b/clusters/nerc-ocp-infra/grafana/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: grafana
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   project: default
   source:
@@ -11,9 +13,3 @@ spec:
   destination:
     name: nerc-ocp-infra
     namespace: grafana
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - Validate=false

--- a/clusters/nerc-ocp-infra/kustomization.yaml
+++ b/clusters/nerc-ocp-infra/kustomization.yaml
@@ -12,3 +12,16 @@ resources:
   - loki
   - logging
   - grafana
+
+patches:
+  - target:
+      kind: Application
+      labelSelector: "nerc.mghpcc.org/sync-policy=common"
+    patch: |
+      - op: add
+        path: /spec/syncPolicy
+        value:
+          automated:
+            selfHeal: true
+          syncOptions:
+            - ApplyOutOfSyncOnly=true

--- a/clusters/nerc-ocp-infra/logging/application.yaml
+++ b/clusters/nerc-ocp-infra/logging/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: logging
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   project: default
   source:
@@ -11,9 +13,3 @@ spec:
   destination:
     name: nerc-ocp-infra
     namespace: openshift-logging
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - Validate=false

--- a/clusters/nerc-ocp-infra/loki/application.yaml
+++ b/clusters/nerc-ocp-infra/loki/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: loki
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   project: default
   source:
@@ -11,9 +13,3 @@ spec:
   destination:
     name: nerc-ocp-infra
     namespace: openshift-operators-redhat
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - Validate=false

--- a/clusters/nerc-ocp-infra/openshift-gitops/application.yaml
+++ b/clusters/nerc-ocp-infra/openshift-gitops/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: nerc-ocp-infra-openshift-gitops
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   destination:
     name: nerc-ocp-infra
@@ -11,8 +13,3 @@ spec:
     path: openshift-gitops/overlays/nerc-ocp-infra
     repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
     targetRevision: HEAD
-  syncPolicy:
-    automated:
-      selfHeal: true
-    syncOptions:
-      - ApplyOutOfSyncOnly=true

--- a/clusters/nerc-ocp-infra/vault/application.yaml
+++ b/clusters/nerc-ocp-infra/vault/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: vault
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   project: default
   source:
@@ -11,9 +13,3 @@ spec:
   destination:
     name: nerc-ocp-infra
     namespace: vault
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - Validate=false

--- a/clusters/nerc-ocp-infra/xdmod/application.yaml
+++ b/clusters/nerc-ocp-infra/xdmod/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: xdmod
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   project: default
   source:
@@ -11,15 +13,3 @@ spec:
   destination:
     name: nerc-ocp-infra
     namespace: xdmod
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - Validate=false
-    retry:
-      limit: -1
-      backoff:
-        duration: 60s
-        factor: 2
-        maxDuration: 30m

--- a/clusters/nerc-ocp-prod/cluster-scope/application.yaml
+++ b/clusters/nerc-ocp-prod/cluster-scope/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: nerc-ocp-prod-cluster-scope
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   destination:
     name: nerc-ocp-prod
@@ -11,8 +13,3 @@ spec:
     repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
     path: cluster-scope/overlays/nerc-ocp-prod
     targetRevision: HEAD
-  syncPolicy:
-    automated:
-      selfHeal: true
-    syncOptions:
-    - ApplyOutOfSyncOnly=true

--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -3,3 +3,17 @@ kind: Kustomization
 resources:
 - cluster-scope/
 - logging/
+
+patches:
+  - target:
+      kind: Application
+      labelSelector: "nerc.mghpcc.org/sync-policy=common"
+    patch: |
+      - op: add
+        path: /spec/syncPolicy
+        value:
+          automated:
+            selfHeal: true
+            prune: false
+          syncOptions:
+            - ApplyOutOfSyncOnly=true

--- a/clusters/nerc-ocp-prod/logging/application.yaml
+++ b/clusters/nerc-ocp-prod/logging/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: logging
+  labels:
+    nerc.mghpcc.org/sync-policy: common
 spec:
   project: default
   source:
@@ -11,9 +13,3 @@ spec:
   destination:
     name: nerc-ocp-prod
     namespace: openshift-logging
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - Validate=false


### PR DESCRIPTION
Remove syncPolicy setting from individual applications and manage it at the
cluster level. For an upcoming change I want the ability to globally set
`prune` to `false`, and this both enables that as well as ensuring a
consistent syncPolicy across our applications.

With this change, applications that have the `nerc.mghpcc.org/sync-policy`
label set to `common` will have their syncPolicy configured via a patch in
the cluster kustomization.yaml.
