### PR TITLE
Add hostpath-provisioner app to nerc-ocp-infra

### DIFF
--- a/clusters/nerc-ocp-infra/hostpath-provisioner/application.yaml
+++ b/clusters/nerc-ocp-infra/hostpath-provisioner/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hostpath-provisioner
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: hostpath-provisioner/overlays/nerc-ocp-infra
+  destination:
+    name: nerc-ocp-infra
+    namespace: kubevirt-hostpath-provisioner

--- a/clusters/nerc-ocp-infra/hostpath-provisioner/kustomization.yaml
+++ b/clusters/nerc-ocp-infra/hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-infra/kustomization.yaml
+++ b/clusters/nerc-ocp-infra/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - xdmod
   - loki
   - grafana
+  - hostpath-provisioner
 
 nameSuffix: -infra
 


### PR DESCRIPTION
Part of: ocp-on-nerc/operations#49
See also: ocp-on-nerc/nerc-ocp-config#173
