### PR TITLE
Add gatekeeper and policy apps

### DIFF
--- a/clusters/lib/gatekeeper/application.yaml
+++ b/clusters/lib/gatekeeper/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gatekeeper
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/gatekeeper.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: gatekeeper-system

--- a/clusters/lib/gatekeeper/kustomization.yaml
+++ b/clusters/lib/gatekeeper/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-prod/gatekeeper-policy/application.yaml
+++ b/clusters/nerc-ocp-prod/gatekeeper-policy/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gatekeeper-policy
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  destination:
+    name: nerc-ocp-prod
+    namespace: gatekeeper-system
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/gatekeeper.git
+    path: policy/overlays/nerc-ocp-prod
+    targetRevision: HEAD

--- a/clusters/nerc-ocp-prod/gatekeeper-policy/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/gatekeeper-policy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
 - ../lib/logging
 - ../lib/ipmi-exporter
 - ../lib/ceph-exporter
+- ../lib/gatekeeper
+- gatekeeper-policy
 - acct-mgt
 - fake-metrics-server
 - xdmod-reader
@@ -62,3 +64,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: overlays/nerc-ocp-prod
+
+  - target:
+      kind: Application
+      name: gatekeeper
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: gatekeeper-system/overlays/nerc-ocp-prod


### PR DESCRIPTION
Add argocd applications for gatekeeper and our gatekeeper policy
definitions. Instantiate these applications on nerc-ocp-prod.

Part of: OCP-on-NERC/operations#95
