### PR TITLE
Adding OpenShift Custom Metrics Autoscaler Operator to OpenShift Prod

### DIFF
--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - acct-mgt
 - fake-metrics-server
 - xdmod-reader
+- openshift-custom-metrics-autoscaler-controller
 
 nameSuffix: -prod
 

--- a/clusters/nerc-ocp-prod/openshift-custom-metrics-autoscaler-controller/application.yaml
+++ b/clusters/nerc-ocp-prod/openshift-custom-metrics-autoscaler-controller/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openshift-custom-metrics-autoscaler-controller
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: openshift-custom-metrics-autoscaler-controller/overlays/nerc-ocp-prod
+  destination:
+    name: nerc-ocp-prod
+    namespace: openshift-keda

--- a/clusters/nerc-ocp-prod/openshift-custom-metrics-autoscaler-controller/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/openshift-custom-metrics-autoscaler-controller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml


### PR DESCRIPTION
The Ecological Forecasting project wishes to scale up their consumers of rabbitmq queues based on the number of messages in the queue. This is an out-of-the-box feature of the OpenShift Custom Metrics Autoscaler Operator. The ScaledObject CRD provided by this operator will allow us to specify the Deployment we wish to scale, the min and max replica count, and the RabbitMQ queue connection details.