### PR TITLE
add nfd-operator app

### DIFF
--- a/clusters/lib/nfd-operator/application.yaml
+++ b/clusters/lib/nfd-operator/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfd-operator
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/OCP-on-NERC/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: openshift-nfd

--- a/clusters/lib/nfd-operator/kustomization.yaml
+++ b/clusters/lib/nfd-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ../lib/ipmi-exporter
 - ../lib/ceph-exporter
 - ../lib/gatekeeper
+- ../lib/nfd-operator
 - gatekeeper-policy
 - acct-mgt
 - fake-metrics-server
@@ -72,3 +73,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: gatekeeper-system/overlays/nerc-ocp-prod
+
+  - target:
+      kind: Application
+      name: nfd-operator
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: nfd-operator/overlays/nerc-ocp-prod

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../lib/cluster-scope
+  - ../lib/nfd-operator
   - curator
   - koku-metrics-operator
 
@@ -34,3 +35,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: cluster-scope/overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: nfd-operator
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: nfd-operator/overlays/nerc-ocp-test


### PR DESCRIPTION
This adds a shared library app for nodefeaturediscovery definitions for both the test and prod clusters.