### PR TITLE
add nvidia-gpu-operator app

### DIFF
--- a/clusters/lib/nvidia-gpu-operator/application.yaml
+++ b/clusters/lib/nvidia-gpu-operator/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nvidia-gpu-operator
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/OCP-on-NERC/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: nvidia-gpu-operator

--- a/clusters/lib/nvidia-gpu-operator/kustomization.yaml
+++ b/clusters/lib/nvidia-gpu-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ../lib/ceph-exporter
 - ../lib/gatekeeper
 - ../lib/nfd-operator
+- ../lib/nvidia-gpu-operator
 - gatekeeper-policy
 - acct-mgt
 - fake-metrics-server
@@ -81,3 +82,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: nfd-operator/overlays/nerc-ocp-prod
+
+  - target:
+      kind: Application
+      name: nvidia-gpu-operator
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: nvidia-gpu-operator/overlays/nerc-ocp-prod

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../lib/cluster-scope
   - ../lib/nfd-operator
+  - ../lib/nvidia-gpu-operator
   - curator
   - koku-metrics-operator
 
@@ -43,3 +44,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: nfd-operator/overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: nvidia-gpu-operator
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: nvidia-gpu-operator/overlays/nerc-ocp-test


### PR DESCRIPTION
This adds a shared library app for NVIDIA GPU operator clusterpolicy definitions for both the test and prod clusters.

Dependency: https://github.com/OCP-on-NERC/nerc-ocp-config/pull/295