### PR TITLE
Add disable-aslr & seccomp-profile-installer apps

### DIFF
--- a/clusters/nerc-ocp-prod/disable-aslr/application.yaml
+++ b/clusters/nerc-ocp-prod/disable-aslr/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: disable-aslr
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  destination:
+    name: nerc-ocp-prod
+    namespace: rhods-notebooks
+  project: default
+  source:
+    repoURL: https://github.com/IsaiahStapleton/disable-aslr-nerc.git
+    path: disable-aslr/overlays/nerc-ocp-prod
+    targetRevision: HEAD

--- a/clusters/nerc-ocp-prod/disable-aslr/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/disable-aslr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-prod/k8s-seccomp-profile-installer/application.yaml
+++ b/clusters/nerc-ocp-prod/k8s-seccomp-profile-installer/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: seccomp-profile-installer
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  destination:
+    name: nerc-ocp-prod
+    namespace: seccomp-profile-installer
+  project: default
+  source:
+    repoURL: https://github.com/IsaiahStapleton/k8s-seccomp-profile-installer.git
+    path: k8s-seccomp-profile-installer/overlays/nerc-ocp-prod
+    targetRevision: HEAD

--- a/clusters/nerc-ocp-prod/k8s-seccomp-profile-installer/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/k8s-seccomp-profile-installer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml


### PR DESCRIPTION
These apps deploy the necessary resources for allowing the personality and ptrace system calls in the rhods-notebooks namespace. This allows us to get the functionality the CS 210 and EC 440 courses need from GDB.