### PR TITLE
Ignore generated fields in grafana serviceaccount token

### DIFF
--- a/clusters/nerc-ocp-infra/grafana/application.yaml
+++ b/clusters/nerc-ocp-infra/grafana/application.yaml
@@ -13,3 +13,9 @@ spec:
   destination:
     name: nerc-ocp-infra
     namespace: grafana
+  ignoreDifferences:
+  - kind: Secret
+    name: grafana-serviceaccount-token
+    namespace: grafana
+    jsonPointers:
+    - /data


### PR DESCRIPTION
We create an "empty" secret for the grafana service account token;
openshift populates several fields in this secret dynamically. ArgoCD is
complaining about these additional fields. This commit instructs ArgoCD to
ignore these differences.
