### PR TITLE
Adding ArgoCD Application for nerc-ocp-obs Observability cluster

### DIFF
--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../lib/cluster-scope
+
+nameSuffix: -obs
+
+patches:
+  - target:
+      kind: Application
+      labelSelector: "nerc.mghpcc.org/sync-policy=common"
+    patch: |
+      - op: add
+        path: /spec/syncPolicy
+        value:
+          automated:
+            selfHeal: true
+          syncOptions:
+            - ApplyOutOfSyncOnly=true
+
+  - target:
+      kind: Application
+    patch: |
+      - op: replace
+        path: /spec/destination/name
+        value: nerc-ocp-obs
+
+  - target:
+      kind: Application
+      name: cluster-scope
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: cluster-scope/overlays/nerc-ocp-obs


### PR DESCRIPTION
This will manage the cluster-scope for the new Observability cluster.

fixes https://github.com/nerc-project/operations/issues/309