### PR TITLE
Configure observability cluster for loki deployment

### DIFF
--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../lib/cluster-scope
+- ../lib/logging
+- loki
 
 nameSuffix: -obs
 
@@ -32,3 +34,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: cluster-scope/overlays/nerc-ocp-obs
+
+  - target:
+      kind: Application
+      name: logging
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: logging/overlays/nerc-ocp-obs

--- a/clusters/nerc-ocp-obs/loki/application.yaml
+++ b/clusters/nerc-ocp-obs/loki/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: loki/overlays/nerc-ocp-obs
+  destination:
+    name: nerc-ocp-obs
+    namespace: openshift-operators-redhat

--- a/clusters/nerc-ocp-obs/loki/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/loki/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml


### PR DESCRIPTION
This PR configures the obs cluster to deploy loki and logging.
Related to https://github.com/OCP-on-NERC/nerc-ocp-config/pull/354