### PR TITLE
Fake metrics endpoint to make ODF happy in obs cluster

### DIFF
--- a/clusters/nerc-ocp-obs/fake-metrics-server/application.yaml
+++ b/clusters/nerc-ocp-obs/fake-metrics-server/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fake-metrics-server
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  destination:
+    name: nerc-ocp-obs
+    namespace: openshift-storage
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    path: fake-metrics-server/overlays/nerc-ocp-obs
+    targetRevision: HEAD

--- a/clusters/nerc-ocp-obs/fake-metrics-server/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/fake-metrics-server/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../lib/cluster-scope
+- fake-metrics-server
 
 nameSuffix: -obs
 


### PR DESCRIPTION
While the "monitoring-endpoint" configuration in OCS 4.8 was optional,
it appears to be required in 4.10, and ODF refuses to deploy if it
can't reach the endpoint.

This commit provides a fake metrics endpoint to make the ODF operator
happy.
