### PR TITLE
Adding nerc-images ArgoCD App

### DIFF
--- a/clusters/lib/nerc-images/application.yaml
+++ b/clusters/lib/nerc-images/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nerc-images
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  destination:
+    name: nerc-ocp-prod
+    namespace: redhat-ods-applications
+  project: default
+  source:
+    repoURL: https://github.com/nerc-images/nerc-images.git
+    path: overlays/nerc-ocp-prod
+    targetRevision: HEAD

--- a/clusters/lib/nerc-images/kustomization.yaml
+++ b/clusters/lib/nerc-images/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../lib/gatekeeper
 - ../lib/nfd-operator
 - ../lib/nvidia-gpu-operator
+- ../lib/nerc-images
 - gatekeeper-policy
 - acct-mgt
 - fake-metrics-server


### PR DESCRIPTION
For deploying NERC and research related ImageStreams, especially
OpenShift AI ImageStreams, to the NERC prod cluster.
