### PR TITLE
Ignore topologyupdater in nodefeaturediscovery manifests

### DIFF
--- a/clusters/lib/nfd-operator/application.yaml
+++ b/clusters/lib/nfd-operator/application.yaml
@@ -13,3 +13,9 @@ spec:
   destination:
     name: REPLACEME
     namespace: openshift-nfd
+  ignoreDifferences:
+    - group: nfd.openshift.io
+      kind: NodeFeatureDiscovery
+      jsonPointers:
+        - /spec/topologyupdater
+        - /spec/topologyUpdater


### PR DESCRIPTION
There appears to be some weirdness around the CRD for the
NodeFeatureDiscovery operator: you need to set the `topologyUpdater`
attribute, but at least on nerc-ocp-test, when you fetch the resource, you
see `toplogyupdater` (note capitalization difference). This causes argocd
to think the app is out of sync.

This commit instructs argocd to ignore either of these names in the
resource.
