### PR TITLE
Adding dex ArgoCD app on obs cluster

### DIFF
--- a/clusters/nerc-ocp-obs/dex/application.yaml
+++ b/clusters/nerc-ocp-obs/dex/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dex
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: dex/overlays/nerc-ocp-obs
+  destination:
+    name: nerc-ocp-obs
+    namespace: dex

--- a/clusters/nerc-ocp-obs/dex/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/dex/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../lib/cluster-scope
 - ../lib/logging
+- dex
 - loki
 - fake-metrics-server
 


### PR DESCRIPTION
We need a dex authentication tool on the obs cluster to authenticate
OpenShift users to grafana for role-based access control.
