### PR TITLE
feat: Adding grafana ArgoCD app on obs cluster

### DIFF
--- a/clusters/nerc-ocp-obs/grafana/application.yaml
+++ b/clusters/nerc-ocp-obs/grafana/application.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grafana
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: grafana/overlays/nerc-ocp-obs
+  destination:
+    name: nerc-ocp-obs
+    namespace: grafana
+  ignoreDifferences:
+  - kind: Secret
+    name: grafana-serviceaccount-token
+    namespace: grafana
+    jsonPointers:
+    - /data

--- a/clusters/nerc-ocp-obs/grafana/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/grafana/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - dex
 - loki
 - fake-metrics-server
-
+- grafana
 
 nameSuffix: -obs
 


### PR DESCRIPTION
We need Grafana on the obs cluster for observability that is not behind the VPN.