### PR TITLE
Add new ArgoCD app to add required KnativeServing and KnativeEventing for Serverless

### DIFF
--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - fake-metrics-server
 - xdmod-reader
 - openshift-custom-metrics-autoscaler-controller
+- serverless
 - software-application-innovation-lab-sail-projects-fcd6dfa
 - smart-village-faeeb6c
 

--- a/clusters/nerc-ocp-prod/serverless/application.yaml
+++ b/clusters/nerc-ocp-prod/serverless/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: serverless
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: serverless/overlays/nerc-ocp-prod
+  destination:
+    name: nerc-ocp-prod
+    namespace: knative-serving

--- a/clusters/nerc-ocp-prod/serverless/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/serverless/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml


### PR DESCRIPTION
- **Add required KnativeServing and KnativeEventing for Serverless**
The BU SAIL team would like to use OpenShift Serverless for a Sign
Language project. To enable this, we add an ArgoCD app to deploy the
default KnativeServing and KnativeEventing resources for Serverless.