### PR TITLE
Adding support for OpenShift Virtualization in test cluster

### DIFF
--- a/clusters/lib/virt/application.yaml
+++ b/clusters/lib/virt/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: virt
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: SET IN OVERLAY
+  destination:
+    name: SET IN OVERLAY
+    namespace: openshift-cnv

--- a/clusters/lib/virt/kustomization.yaml
+++ b/clusters/lib/virt/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../lib/nfd-operator
   - ../lib/nvidia-gpu-operator
   - ../lib/logging
+  - ../lib/virt
 
 nameSuffix: -test
 
@@ -59,3 +60,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: logging/overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: virt
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: virt/overlays/nerc-ocp-test


### PR DESCRIPTION
As documented in the Red Hat OpenShift Virtualization docs[1].

Closes nerc-project/operations#489
