### PR TITLE
nerc-ocp-test: add nfs and csi-driver-nfs apps

### DIFF
--- a/clusters/lib/csi-driver-nfs/application.yaml
+++ b/clusters/lib/csi-driver-nfs/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: csi-driver-nfs
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/OCP-on-NERC/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: csi-driver-nfs

--- a/clusters/lib/csi-driver-nfs/kustomization.yaml
+++ b/clusters/lib/csi-driver-nfs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - application.yaml

--- a/clusters/lib/nfs/application.yaml
+++ b/clusters/lib/nfs/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfs
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/OCP-on-NERC/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: nfs

--- a/clusters/lib/nfs/kustomization.yaml
+++ b/clusters/lib/nfs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - application.yaml

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../lib/logging
   - ../lib/virt
   - ../lib/nfs
+  - ../lib/csi-driver-nfs
 
 nameSuffix: -test
 
@@ -77,3 +78,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: nfs/overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: csi-driver-nfs
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: csi-driver-nfs/overlays/nerc-ocp-test

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../lib/nvidia-gpu-operator
   - ../lib/logging
   - ../lib/virt
+  - ../lib/nfs
 
 nameSuffix: -test
 
@@ -68,3 +69,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: virt/overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: nfs
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: nfs/overlays/nerc-ocp-test


### PR DESCRIPTION
This deploys an NFS server on `nerc-ocp-test` that uses RBD storage as the NFS share and configures a CSI driver for NFS that points to the locally-deployed, RBD-backed, NFS server running on OpenShift.

See https://github.com/OCP-on-NERC/nerc-ocp-config/pull/539