### PR TITLE
Adding dex and minio to nerc-ocp-test cluster

### DIFF
--- a/clusters/nerc-ocp-test/dex/application.yaml
+++ b/clusters/nerc-ocp-test/dex/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dex
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: dex/overlays/nerc-ocp-test
+  destination:
+    name: nerc-ocp-test
+    namespace: dex

--- a/clusters/nerc-ocp-test/dex/kustomization.yaml
+++ b/clusters/nerc-ocp-test/dex/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - ../lib/nfs
   - ../lib/csi-driver-nfs
   - ../lib/autopilot
+  - dex
+  - minio
 
 nameSuffix: -test
 

--- a/clusters/nerc-ocp-test/minio/application.yaml
+++ b/clusters/nerc-ocp-test/minio/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: minio
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: minio/overlays/nerc-ocp-test
+  destination:
+    name: nerc-ocp-test
+    namespace: minio

--- a/clusters/nerc-ocp-test/minio/kustomization.yaml
+++ b/clusters/nerc-ocp-test/minio/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml


### PR DESCRIPTION
Adding dex and minio for authenticated object storage in the test
cluster to replace NooBaa.
