### PR TITLE
Add minio to the obs cluster

### DIFF
--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ../lib/logging
 - ../lib/autopilot
 - dex
+- minio
 - loki
 - fake-metrics-server
 - grafana

--- a/clusters/nerc-ocp-obs/minio/application.yaml
+++ b/clusters/nerc-ocp-obs/minio/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: minio
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: minio/overlays/nerc-ocp-obs
+  destination:
+    name: nerc-ocp-obs
+    namespace: minio

--- a/clusters/nerc-ocp-obs/minio/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/minio/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml


### PR DESCRIPTION
We will be using minio object storage for loki logs, metrics, and open
telemetry on the obs cluster.
