### PR TITLE
Add OpenTelemetry and Tempo for AI Telemetry in obs

### DIFF
--- a/clusters/lib/opentelemetry/application.yaml
+++ b/clusters/lib/opentelemetry/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opentelemetry
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: opentelemetry

--- a/clusters/lib/opentelemetry/kustomization.yaml
+++ b/clusters/lib/opentelemetry/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../lib/cluster-scope
 - ../lib/logging
 - ../lib/autopilot
+- ../lib/opentelemetry
 - dex
 - minio
 - loki
@@ -58,3 +59,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: autopilot/overlays/nerc-ocp-obs
+
+  - target:
+      kind: Application
+      name: opentelemetry
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: opentelemetry/overlays/nerc-ocp-obs


### PR DESCRIPTION
Adds a working TempoStack and OpenTelemetryCollector to the obs cluster
connected to Minio object storage to begin collecting telemetry traces
and metrics.
