### PR TITLE
Add snmp-exporter metrics to obs cluster

### DIFF
--- a/clusters/lib/snmp-exporter/application.yaml
+++ b/clusters/lib/snmp-exporter/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: snmp-exporter
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: snmp-exporter

--- a/clusters/lib/snmp-exporter/kustomization.yaml
+++ b/clusters/lib/snmp-exporter/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ../lib/logging
 - ../lib/autopilot
 - ../lib/opentelemetry
+- ../lib/snmp-exporter
 - dex
 - minio
 - loki
@@ -67,3 +68,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: opentelemetry/overlays/nerc-ocp-obs
+
+  - target:
+      kind: Application
+      name: snmp-exporter
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: snmp-exporter/overlays/nerc-ocp-obs


### PR DESCRIPTION
This adds an overlay for the nerc-ocp-obs cluster to install the
snmp-exporter with metrics for network switches.
