### PR TITLE
Deploying Griot and Grits on nerc-ocp-test

### DIFF
--- a/clusters/nerc-ocp-test/griot-grits/application-set.yaml
+++ b/clusters/nerc-ocp-test/griot-grits/application-set.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: griot-and-grits-apps
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  syncPolicy:
+    preserveResourcesOnDeletion: false
+    applicationsSync: "sync" 
+  generators:
+  - git:
+      repoURL: https://github.com/griot-and-grits/griot-and-grits-infra.git
+      revision: main
+      files:
+      - path: applications/*/kustomization.yaml
+  template:
+    metadata:
+      name: '{{.path.basename}}'
+      labels:
+        app.kubernetes.io/name: '{{.path.basename}}'
+        app.kubernetes.io/component: griot-and-grits
+        app.kubernetes.io/part-of: griot-and-grits
+        nerc.mghpcc.org/sync-policy: common
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/griot-and-grits/griot-and-grits-infra.git
+        targetRevision: main
+        path: '{{.path.path}}'
+      destination:
+        name: nerc-ocp-test
+        namespace: 'griot-grits'
+      syncPolicy:
+        syncOptions:
+        - CreateNamespace=true

--- a/clusters/nerc-ocp-test/griot-grits/application-set.yaml
+++ b/clusters/nerc-ocp-test/griot-grits/application-set.yaml
@@ -7,7 +7,7 @@ spec:
   goTemplateOptions: ["missingkey=error"]
   syncPolicy:
     preserveResourcesOnDeletion: false
-    applicationsSync: "sync" 
+    applicationsSync: "sync"
   generators:
   - git:
       repoURL: https://github.com/griot-and-grits/griot-and-grits-infra.git

--- a/clusters/nerc-ocp-test/griot-grits/kustomization.yaml
+++ b/clusters/nerc-ocp-test/griot-grits/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/griot-and-grits/griot-and-grits-infra.git?ref=main
+  - application-set.yaml

--- a/clusters/nerc-ocp-test/griot-grits/kustomization.yaml
+++ b/clusters/nerc-ocp-test/griot-grits/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://github.com/griot-and-grits/griot-and-grits-infra.git?ref=main

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ../lib/autopilot
   - dex
   - minio
+  - griot-grits
 
 nameSuffix: -test
 


### PR DESCRIPTION
Deploying applicationSet instead of application to allow for individual applications to be created for each application we need to deploy as a part of the Griot and Grits project