### PR TITLE
add ccb-operator-crds app

### DIFF
--- a/clusters/lib/ccb-operator-crds/application.yaml
+++ b/clusters/lib/ccb-operator-crds/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ccb-operator-crds
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  destination:
+    name: SET IN OVERLAY
+    namespace: openshift-gitops
+  project: default
+  source:
+    path: SET IN OVERLAY
+    repoURL: https://github.com/OCP-on-NERC/nerc-vega-ccb-operator-crds.git
+    targetRevision: HEAD

--- a/clusters/lib/ccb-operator-crds/kustomization.yaml
+++ b/clusters/lib/ccb-operator-crds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/clusters/nerc-ocp-prod/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ../lib/nvidia-gpu-operator
 - ../lib/nerc-images
 - ../lib/autopilot
+- ../lib/ccb-operator-crds
 - gatekeeper-policy
 - acct-mgt
 - curator
@@ -106,3 +107,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: autopilot/overlays/nerc-ocp-prod
+
+  - target:
+      kind: Application
+      name: ccb-operator-crds
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: overlays/nerc-ocp-prod


### PR DESCRIPTION
This adds a shared library app for vega-project's ccb-operator CRDs:

https://github.com/vega-project/ccb-operator/tree/master/pkg/apis

The operator runs completely within the vega-project's namespace on NERC and is managed by the end user. This app simply installs the CRDs needed by the operator.

See: https://github.com/CCI-MOC/ops-issues/issues/1500