### PR TITLE
nerc-ocp-test: fix griot and grits applicationset

### DIFF
--- a/clusters/nerc-ocp-test/griot-grits/application-set.yaml
+++ b/clusters/nerc-ocp-test/griot-grits/application-set.yaml
@@ -9,7 +9,7 @@ spec:
     preserveResourcesOnDeletion: false
   generators:
   - git:
-      repoURL: https://github.com/griot-and-grits/griot-and-grits-infra.git
+      repoURL: https://github.com/OCP-on-NERC/griot-and-grits-infra.git
       revision: main
       files:
       - path: applications/*/kustomization.yaml

--- a/clusters/nerc-ocp-test/griot-grits/application-set.yaml
+++ b/clusters/nerc-ocp-test/griot-grits/application-set.yaml
@@ -7,7 +7,6 @@ spec:
   goTemplateOptions: ["missingkey=error"]
   syncPolicy:
     preserveResourcesOnDeletion: false
-    applicationsSync: "sync"
   generators:
   - git:
       repoURL: https://github.com/griot-and-grits/griot-and-grits-infra.git


### PR DESCRIPTION
This is a patch to #64 

- remove unknown field applicationsSync
- use NERC fork of the griot-and-grits-infra repo

We should be using forks of any manifest repos given that NERC admins are not in control of those repos and argocd runs with admin privileges.