### PR TITLE
nerc-ocp-test: remove goTemplate fields from griot-and-grits applicationset

### DIFF
--- a/clusters/nerc-ocp-test/griot-grits/application-set.yaml
+++ b/clusters/nerc-ocp-test/griot-grits/application-set.yaml
@@ -3,8 +3,6 @@ kind: ApplicationSet
 metadata:
   name: griot-and-grits-apps
 spec:
-  goTemplate: true
-  goTemplateOptions: ["missingkey=error"]
   syncPolicy:
     preserveResourcesOnDeletion: false
   generators:


### PR DESCRIPTION
These appear to be valid fields according to:

https://argo-cd.readthedocs.io/en/stable/user-guide/application-set/

However, the spec for `argoproj.io.ApplicationSet/v1alpha` on the `nerc-ocp-infra` cluster is missing these fields:
```
$ oc explain appset.spec.goTemplate
GROUP:      argoproj.io
KIND:       ApplicationSet
VERSION:    v1alpha1

error: field "goTemplate" does not exist

$ oc explain appset.spec.goTemplateOptions
GROUP:      argoproj.io
KIND:       ApplicationSet
VERSION:    v1alpha1

error: field "goTemplateOptions" does not exist
```
ArgoCD is also complaining about these fields when attempting to sync.