### PR TITLE
Fix syntax to match version of Argo running

### DIFF
--- a/clusters/nerc-ocp-test/griot-grits/application-set.yaml
+++ b/clusters/nerc-ocp-test/griot-grits/application-set.yaml
@@ -13,9 +13,9 @@ spec:
       - path: applications/*/kustomization.yaml
   template:
     metadata:
-      name: '{{.path.basename}}'
+      name: '{{path.basename}}'
       labels:
-        app.kubernetes.io/name: '{{.path.basename}}'
+        app.kubernetes.io/name: '{{path.basename}}'
         app.kubernetes.io/component: griot-and-grits
         app.kubernetes.io/part-of: griot-and-grits
         nerc.mghpcc.org/sync-policy: common
@@ -24,7 +24,7 @@ spec:
       source:
         repoURL: https://github.com/griot-and-grits/griot-and-grits-infra.git
         targetRevision: main
-        path: '{{.path.path}}'
+        path: '{{path}}'
       destination:
         name: nerc-ocp-test
         namespace: 'griot-grits'


### PR DESCRIPTION
The syntax in this manifest matches to docs for the new version of ArgoCD however we are still running a pretty old version. This has already been tested on the cluster.