### PR TITLE
Add ipmi-exporter to hypershift and nerc-ocp clusters

### DIFF
--- a/clusters/hypershift1/kustomization.yaml
+++ b/clusters/hypershift1/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../lib/cluster-scope
+  - ../lib/ipmi-exporter
 
 nameSuffix: -hypershift1
 
@@ -32,3 +33,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: cluster-scope/overlays/hypershift1
+
+  - target:
+      kind: Application
+      name: ipmi-exporter
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: overlays/hypershift1

--- a/clusters/hypershift2/kustomization.yaml
+++ b/clusters/hypershift2/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../lib/cluster-scope
+  - ../lib/ipmi-exporter
 
 nameSuffix: -hypershift2
 
@@ -32,6 +33,14 @@ patches:
       - op: replace
         path: /spec/source/path
         value: cluster-scope/overlays/hypershift2
+
+  - target:
+      kind: Application
+      name: ipmi-exporter
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: overlays/hypershift2
 
   - target:
       kind: Application

--- a/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/clusters/nerc-ocp-obs/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ../lib/autopilot
 - ../lib/opentelemetry
 - ../lib/snmp-exporter
+- ../lib/ipmi-exporter
 - dex
 - minio
 - loki
@@ -76,3 +77,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: snmp-exporter/overlays/nerc-ocp-obs
+
+  - target:
+      kind: Application
+      name: ipmi-exporter
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: overlays/nerc-ocp-obs

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../lib/nfs
   - ../lib/csi-driver-nfs
   - ../lib/autopilot
+  - ../lib/ipmi-exporter
   - dex
   - minio
   - griot-grits
@@ -98,3 +99,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: autopilot/overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: ipmi-exporter
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: overlays/nerc-ocp-test


### PR DESCRIPTION
This is so we can get BMC metrics from managed clusters.

Closes innabox/observability-wg#13