### PR TITLE
feat(metering): wire opentelemetry overlay for nerc-ocp-test

### DIFF
--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../lib/csi-driver-nfs
   - ../lib/autopilot
   - ../lib/ipmi-exporter
+  - ../lib/costmanagement
   - ../lib/opentelemetry
   - dex
   - minio
@@ -108,6 +109,14 @@ patches:
       - op: replace
         path: /spec/source/path
         value: overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: costmanagement
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: costmanagement/overlays/nerc-ocp-test
 
   - target:
       kind: Application

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../lib/csi-driver-nfs
   - ../lib/autopilot
   - ../lib/ipmi-exporter
+  - ../lib/opentelemetry
   - dex
   - minio
   - griot-grits
@@ -107,3 +108,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: opentelemetry
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: opentelemetry/overlays/nerc-ocp-test


### PR DESCRIPTION
## Summary

- Adds `../lib/opentelemetry` to `clusters/nerc-ocp-test/kustomization.yaml`
- Patches `spec.source.path` → `opentelemetry/overlays/nerc-ocp-test`

## Order
  1. PR#77 (nerc-ocp-apps, OTel)
  2. nerc-ocp-config PRs #912, #914–#918 (1→6)                                                                                                
  3. PR#78 (nerc-ocp-apps, Metering)  

## Context

Part of the metering stack rollout for nerc-ocp-test. The OTel collector on nerc-ocp-test forwards billing events to Kafka (`metering-kafka-bootstrap.metering-thor.svc:9093`). Without this ArgoCD Application, the overlay in `nerc-ocp-config` would never deploy.

Related PRs in nerc-ocp-config:
- PR #914: feat(metering): add OTel collector billing patch for nerc-ocp-test [2/6]

## Test plan

- [ ] `kustomize build clusters/nerc-ocp-test` builds without errors
- [ ] ArgoCD Application `opentelemetry-test` appears on nerc-ocp-infra after merge
- [ ] OTel collector pod running in `opentelemetry` namespace on nerc-ocp-test