### PR TITLE
feat(metering): add metering ArgoCD Application for nerc-ocp-test

### DIFF
--- a/clusters/lib/metering/application.yaml
+++ b/clusters/lib/metering/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metering
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: metering-thor

--- a/clusters/lib/metering/kustomization.yaml
+++ b/clusters/lib/metering/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../lib/csi-driver-nfs
   - ../lib/autopilot
   - ../lib/ipmi-exporter
+  - ../lib/opentelemetry
   - dex
   - minio
   - griot-grits
@@ -107,3 +108,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: opentelemetry
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: opentelemetry/overlays/nerc-ocp-test

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ../lib/autopilot
   - ../lib/ipmi-exporter
   - ../lib/opentelemetry
+  - ../lib/metering
   - dex
   - minio
   - griot-grits
@@ -116,3 +117,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: opentelemetry/overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: metering
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: metering/overlays/nerc-ocp-test

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../lib/csi-driver-nfs
   - ../lib/autopilot
   - ../lib/ipmi-exporter
+  - ../lib/costmanagement
   - ../lib/opentelemetry
   - ../lib/metering
   - dex
@@ -109,6 +110,14 @@ patches:
       - op: replace
         path: /spec/source/path
         value: overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: costmanagement
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: costmanagement/overlays/nerc-ocp-test
 
   - target:
       kind: Application


### PR DESCRIPTION
## Summary

- Adds `clusters/lib/metering/` with ArgoCD `Application` template (follows existing `lib/opentelemetry` pattern)
- Adds `../lib/metering` to `clusters/nerc-ocp-test/kustomization.yaml`
- Patches `spec.source.path` → `metering/overlays/nerc-ocp-test`

## Context

Part of the metering stack rollout for nerc-ocp-test. Without this ArgoCD Application, the metering overlay in `nerc-ocp-config` will never deploy to the cluster.

**Merge order:** This PR must be merged **after** all 6 nerc-ocp-config metering PRs (#912, #914–#918) are merged, as ArgoCD will immediately attempt to sync `metering/overlays/nerc-ocp-test` once this Application exists.

Related PRs in nerc-ocp-config:
- PR #912: feat(metering): add namespace and Kafka for nerc-ocp-test [1/6]
- PR #914: feat(metering): add OTel collector billing patch for nerc-ocp-test [2/6]
- PR #915: feat(metering): add reconciler CronJob for nerc-ocp-test [3/6]
- PR #916: feat(metering): add ClickHouse billing DB for nerc-ocp-test [4/6]
- PR #917: feat(metering): add stream processor placeholder for nerc-ocp-test [5/6]
- PR #918: feat(metering): add OpenMeter self-hosted meter engine for nerc-ocp-test [6/6]

Related PR in nerc-ocp-apps:
- PR #77: feat(metering): wire opentelemetry overlay for nerc-ocp-test

## Test plan

- [ ] `kustomize build clusters/nerc-ocp-test` builds without errors
- [ ] ArgoCD Application `metering-test` appears on nerc-ocp-infra after merge
- [ ] All metering pods running in `metering-thor` namespace on nerc-ocp-test