### PR TITLE
Adding CostManagementMetricsConfig to nerc-ocp-test

### DIFF
--- a/clusters/lib/costmanagement/application.yaml
+++ b/clusters/lib/costmanagement/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: costmanagement
+  labels:
+    nerc.mghpcc.org/sync-policy: common
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ocp-on-nerc/nerc-ocp-config.git
+    targetRevision: HEAD
+    path: REPLACEME
+  destination:
+    name: REPLACEME
+    namespace: costmanagement-metrics-operator

--- a/clusters/lib/costmanagement/kustomization.yaml
+++ b/clusters/lib/costmanagement/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/clusters/nerc-ocp-test/kustomization.yaml
+++ b/clusters/nerc-ocp-test/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../lib/csi-driver-nfs
   - ../lib/autopilot
   - ../lib/ipmi-exporter
+  - ../lib/costmanagement
   - dex
   - minio
   - griot-grits
@@ -107,3 +108,11 @@ patches:
       - op: replace
         path: /spec/source/path
         value: overlays/nerc-ocp-test
+
+  - target:
+      kind: Application
+      name: costmanagement
+    patch: |
+      - op: replace
+        path: /spec/source/path
+        value: costmanagement/overlays/nerc-ocp-test


### PR DESCRIPTION
This provides Cost Management On Prem for the nerc-ocp-test cluster by
setting upload_toggle: false.
